### PR TITLE
Allow duplicate labels

### DIFF
--- a/Memrise_Course_Importer/memrise.py
+++ b/Memrise_Course_Importer/memrise.py
@@ -318,16 +318,18 @@ class CourseLoader(object):
         pool.name = data["name"]
         
         for index, column in sorted(data["columns"].items()):
+            key = '{}:{}'.format(index, column['label'])
             if (column['kind'] == 'text'):
-                pool.textColumns[column['label']] = index
+                pool.textColumns[key] = index
             elif (column['kind'] == 'audio'):
-                pool.audioColumns[column['label']] = index
+                pool.audioColumns[key] = index
             elif (column['kind'] == 'image'):
-                pool.imageColumns[column['label']] = index
+                pool.imageColumns[key] = index
 
         for index, attribute in sorted(data["attributes"].items()):
             if (attribute['kind'] == 'text'):
-                pool.attributes[attribute['label']] = index
+                key = '{}:{}'.format(index, attribute['label'])
+                pool.attributes[key] = index
         
         return pool
     


### PR DESCRIPTION
Importing the course [English Visual Dictionary](http://www.memrise.com/course/54235/english-visual-dictionary/) fails, because the course contains two fields with the same label:

```
pools: {
  columns: {
    "5": {
      kind: "text",
      typing_disabled: false,
      typing_strict: false,
      label: "Text",
      always_show: false,
      classes: [ ],
      keyboard: "",
      tapping_disabled: false
    },
    "7": {
      kind: "text",
      typing_disabled: false,
      typing_strict: false,
      label: "Text",
      always_show: true,
      classes: [ ],
      keyboard: "",
      tapping_disabled: false
    }
    ...
```

This PR contains a quick fix for the problem.
